### PR TITLE
feat: dynamic OpenCode Go model catalog with disk cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Added
+- Dynamic OpenCode Go model catalog. The CLI now fetches the live model list
+  from `https://opencode.ai/zen/v1/models` on demand instead of relying on a
+  hand-maintained hardcoded array, so newly released models (e.g. `kimi-k2.6`,
+  `qwen3.6-plus`, `big-pickle`, new free-tier entries) show up automatically.
+  Results are cached on disk in `~/.opencode-go-cli/opencode-models.json`
+  with a 1-hour TTL and fall back to a built-in snapshot when the endpoint
+  is unreachable. New `--refresh-models` flag forces a cache bypass.
+- `src/providers/opencode-models.ts` with `getOpenCodeModels()` and
+  `humanizeModelId()`. Covered by 13 unit tests that exercise network,
+  cache, refresh, offline, fallback, and normalization paths.
+
+### Changed
+- `--list` (without `--provider`, or with `--provider opencode`) now shows
+  the live list. Other providers (`openai`, `qwen`, `zai`) continue to use
+  their existing static model lists.
+- The built-in OpenCode Go fallback in `src/constants.ts` was expanded from
+  5 entries to 13 so it remains useful offline.
 
 ## [1.0.6] - 2026-04-15
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Core capabilities:
 
 ### OpenCode Go (`--provider opencode`)
 
-| ID | Name | Description |
-|----|------|-------------|
-| `minimax-m2.5` | MiniMax M2.5 | Balanced speed and quality |
-| `minimax-m2.7` | MiniMax M2.7 | High performance coding model |
-| `kimi-k2.5` | Kimi K2.5 | Strong reasoning for complex tasks |
-| `glm-5` | GLM-5 | Latest generation from Zhipu AI |
-| `glm-5.1` | GLM-5.1 | Enhanced reasoning from Zhipu AI |
+The OpenCode Go model list is fetched live from
+`https://opencode.ai/zen/v1/models` and cached locally for one hour. Run
+`opencode-go --list` to see the current catalog (40+ models at the time of
+writing, including Claude, Gemini, GPT, GLM, MiniMax, Kimi, Qwen, and free-tier
+entries). Use `opencode-go --refresh-models` (or `--list --refresh-models`)
+to force a refresh. When the endpoint is unreachable the CLI falls back to a
+built-in snapshot of the most common models.
 
 ### OpenAI (`--provider openai`)
 
@@ -120,6 +120,10 @@ opencode-go --list
 opencode-go --list --provider openai
 opencode-go --list --provider qwen
 opencode-go --list --provider zai
+opencode-go --list --refresh-models   # force OpenCode model cache refresh
+
+# Refresh OpenCode model cache without listing
+opencode-go --refresh-models
 
 # Proxy only
 opencode-go --proxy --port 8080
@@ -259,6 +263,8 @@ src/
 |   |-- zai-handler.ts
 |   |-- zai-signature.ts
 |   `-- zai-stream.ts
+|-- providers/
+|   `-- opencode-models.ts
 `-- search/
     `-- searxng.ts
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,6 @@ import { spawn } from "node:child_process";
 import { open } from "node:fs/promises";
 import * as p from "@clack/prompts";
 import {
-  MODELS,
   OPENAI_MODELS,
   QWEN_MODELS,
   ZAI_MODELS,
@@ -15,8 +14,13 @@ import {
   PROVIDERS,
   buildQwenChatCompletionsUrl,
   buildQwenHeaders,
+  type Model,
   type Provider,
 } from "./constants.js";
+import {
+  clearOpenCodeModelsCache,
+  getOpenCodeModels,
+} from "./providers/opencode-models.js";
 import { getConfig, saveConfig, resetAll } from "./config.js";
 import { resolveClaudePath } from "./path.js";
 import { buildClaudeEnv } from "./env.js";
@@ -487,16 +491,30 @@ async function selectProvider(): Promise<Provider> {
   return provider as Provider;
 }
 
+async function resolveModelsForProvider(
+  provider: Provider,
+  options: { refresh?: boolean } = {},
+): Promise<Model[]> {
+  if (provider === "openai") return OPENAI_MODELS;
+  if (provider === "qwen") return QWEN_MODELS;
+  if (provider === "zai") return ZAI_MODELS;
+
+  const spinner = p.spinner();
+  spinner.start(options.refresh ? "Refreshing OpenCode models..." : "Loading OpenCode models...");
+  const result = await getOpenCodeModels({ refresh: options.refresh });
+  if (result.source === "network") {
+    spinner.stop(`Loaded ${result.models.length} models from opencode.ai`);
+  } else if (result.source === "cache") {
+    spinner.stop(`Loaded ${result.models.length} cached models`);
+  } else {
+    spinner.stop(`Using built-in fallback (${result.models.length} models)`);
+  }
+  return result.models;
+}
+
 async function selectModel(provider: Provider): Promise<string> {
   const config = getConfig();
-  const models =
-    provider === "openai"
-      ? OPENAI_MODELS
-      : provider === "qwen"
-        ? QWEN_MODELS
-        : provider === "zai"
-          ? ZAI_MODELS
-          : MODELS;
+  const models = await resolveModelsForProvider(provider);
 
   const model = await p.select({
     message: "Select model:",
@@ -891,15 +909,9 @@ export async function main(): Promise<void> {
 
   if (args.includes("--list")) {
     const providerIndex = args.indexOf("--provider");
-    const providerName = providerIndex !== -1 ? args[providerIndex + 1] : "opencode";
-    const models =
-      providerName === "openai"
-        ? OPENAI_MODELS
-        : providerName === "qwen"
-          ? QWEN_MODELS
-          : providerName === "zai"
-            ? ZAI_MODELS
-            : MODELS;
+    const providerName = (providerIndex !== -1 ? args[providerIndex + 1] : "opencode") as Provider;
+    const refresh = args.includes("--refresh-models");
+    const models = await resolveModelsForProvider(providerName, { refresh });
     const label =
       providerName === "openai"
         ? "OpenAI (GPT-5.x)"
@@ -910,10 +922,26 @@ export async function main(): Promise<void> {
             : "OpenCode Go";
     console.log(`\nAvailable models (${label}):\n`);
     for (const model of models) {
-      console.log(`  ${model.id.padEnd(20)} ${model.name}`);
-      console.log(`  ${"".padEnd(20)} ${model.description}\n`);
+      console.log(`  ${model.id.padEnd(28)} ${model.name}`);
+      if (model.description) {
+        console.log(`  ${"".padEnd(28)} ${model.description}`);
+      }
+      console.log();
     }
     process.exit(0);
+  }
+
+  if (args.includes("--refresh-models") && !args.includes("--list")) {
+    const spinner = p.spinner();
+    spinner.start("Refreshing OpenCode models from opencode.ai...");
+    clearOpenCodeModelsCache();
+    const result = await getOpenCodeModels({ refresh: true });
+    if (result.source === "network") {
+      spinner.stop(`Cached ${result.models.length} models.`);
+      process.exit(0);
+    }
+    spinner.stop("Refresh failed — using fallback.");
+    process.exit(1);
   }
 
   // ─── Proxy-only mode ───
@@ -987,14 +1015,7 @@ export async function main(): Promise<void> {
   if (hasOverrides) {
     // Validate model if both provider and model specified
     if (modelOverride && providerOverride) {
-      const modelList =
-        providerOverride === "openai"
-          ? OPENAI_MODELS
-          : providerOverride === "qwen"
-            ? QWEN_MODELS
-            : providerOverride === "zai"
-              ? ZAI_MODELS
-              : MODELS;
+      const modelList = await resolveModelsForProvider(providerOverride);
       if (!modelList.find((m) => m.id === modelOverride)) {
         p.log.error(`Unknown model: ${modelOverride}`);
         p.log.info(`Run 'opencode-go --list --provider ${providerOverride}' to see available models.`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,15 +35,30 @@ export type Provider = typeof PROVIDERS[number];
 
 // ─── OpenCode Go (default) ────────────────────────────────
 
+// Fallback snapshot of the OpenCode Zen catalog. Used only when the live
+// /zen/v1/models endpoint is unreachable. Updated 2026-04. For the current
+// list, the CLI fetches the catalog at runtime — see
+// src/providers/opencode-models.ts.
 export const MODELS: Model[] = [
-  { id: "minimax-m2.5", name: "MiniMax M2.5", description: "Balanced speed and quality" },
   { id: "minimax-m2.7", name: "MiniMax M2.7", description: "High performance coding model" },
+  { id: "minimax-m2.5", name: "MiniMax M2.5", description: "Balanced speed and quality" },
+  { id: "minimax-m2.5-free", name: "MiniMax M2.5 (Free)", description: "Free tier" },
+  { id: "kimi-k2.6", name: "Kimi K2.6", description: "Latest Kimi reasoning model" },
   { id: "kimi-k2.5", name: "Kimi K2.5", description: "Strong reasoning for complex tasks" },
-  { id: "glm-5", name: "GLM-5", description: "Latest generation from Zhipu AI" },
   { id: "glm-5.1", name: "GLM-5.1", description: "Enhanced reasoning from Zhipu AI" },
+  { id: "glm-5", name: "GLM-5", description: "Latest generation from Zhipu AI" },
+  { id: "qwen3.6-plus", name: "Qwen3.6 Plus", description: "Latest Qwen3 flagship" },
+  { id: "qwen3.5-plus", name: "Qwen3.5 Plus", description: "Qwen3 flagship" },
+  { id: "big-pickle", name: "Big Pickle", description: "OpenCode house model" },
+  { id: "ling-2.6-flash-free", name: "Ling 2.6 Flash (Free)", description: "Free tier" },
+  { id: "trinity-large-preview-free", name: "Trinity Large Preview (Free)", description: "Free tier preview" },
+  { id: "nemotron-3-super-free", name: "Nemotron 3 Super (Free)", description: "Free tier" },
 ];
 
 export const OPENCODE_GO_ENDPOINT = "https://opencode.ai/zen/go/v1/chat/completions";
+export const OPENCODE_MODELS_ENDPOINT = "https://opencode.ai/zen/v1/models";
+export const OPENCODE_MODELS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+export const OPENCODE_MODELS_FETCH_TIMEOUT_MS = 5_000;
 
 // ─── OpenAI / Codex (OAuth) ─────────────────────────────
 
@@ -170,6 +185,7 @@ export const ZAI_TIME_BUCKET_MS = 5 * 60 * 1000; // 5 minutes
 export const CONFIG_DIR = join(homedir(), ".opencode-go-cli");
 export const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 export const QWEN_DB_FILE = join(CONFIG_DIR, "qwen.db");
+export const OPENCODE_MODELS_CACHE_FILE = join(CONFIG_DIR, "opencode-models.json");
 export const INSTALLATIONS_DIR = join(CONFIG_DIR, "installations");
 export const DEFAULT_INSTALLATION_ID = "default";
 export const DEFAULT_PROXY_PORT = 8080;

--- a/src/providers/opencode-models.ts
+++ b/src/providers/opencode-models.ts
@@ -1,0 +1,234 @@
+// ============================================================
+// OpenCode Go — dynamic model catalog
+//
+// Fetches the live list of models from https://opencode.ai/zen/v1/models
+// (OpenAI-compatible `object: "list"` payload). Caches the normalized
+// result on disk with a 1h TTL. Falls back to the static `MODELS`
+// snapshot in `constants.ts` when the fetch fails.
+// ============================================================
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  MODELS,
+  OPENCODE_MODELS_CACHE_FILE,
+  OPENCODE_MODELS_CACHE_TTL_MS,
+  OPENCODE_MODELS_ENDPOINT,
+  OPENCODE_MODELS_FETCH_TIMEOUT_MS,
+  type Model,
+} from "../constants.js";
+import { createLogger } from "../logger.js";
+
+function resolveCacheFile(): string {
+  return process.env["OPENCODE_MODELS_CACHE_FILE_OVERRIDE"] || OPENCODE_MODELS_CACHE_FILE;
+}
+
+const log = createLogger("[opencode-models]");
+
+interface CacheFile {
+  version: 1;
+  fetchedAt: number;
+  models: Model[];
+}
+
+interface ModelsApiResponse {
+  object?: string;
+  data?: Array<{ id?: unknown; owned_by?: unknown }>;
+}
+
+let memoryCache: { fetchedAt: number; models: Model[] } | null = null;
+
+// Capitalization map for known vendor / variant segments. Anything not
+// in this map falls through untouched (preserves version strings like
+// "4.7", "m2.5", etc.).
+const SEGMENT_MAP: Record<string, string> = {
+  gpt: "GPT",
+  glm: "GLM",
+  claude: "Claude",
+  gemini: "Gemini",
+  kimi: "Kimi",
+  qwen: "Qwen",
+  ling: "Ling",
+  minimax: "MiniMax",
+  nemotron: "Nemotron",
+  trinity: "Trinity",
+  opus: "Opus",
+  sonnet: "Sonnet",
+  haiku: "Haiku",
+  pro: "Pro",
+  flash: "Flash",
+  mini: "Mini",
+  nano: "Nano",
+  max: "Max",
+  turbo: "Turbo",
+  plus: "Plus",
+  codex: "Codex",
+  coder: "Coder",
+  spark: "Spark",
+  large: "Large",
+  preview: "Preview",
+};
+
+const NUMERIC_SEGMENT = /^\d+(?:\.\d+)*$/;
+
+export function humanizeModelId(id: string): string {
+  const segments = id.split("-");
+  const isFree = segments.at(-1) === "free";
+  const core = isFree ? segments.slice(0, -1) : segments;
+  const pretty = core.map((seg) => SEGMENT_MAP[seg.toLowerCase()] ?? seg);
+  // Join consecutive numeric segments with `.` so "claude-opus-4-7" reads
+  // as "Claude Opus 4.7" instead of "Claude Opus 4 7".
+  let out = "";
+  for (let i = 0; i < pretty.length; i++) {
+    const seg = pretty[i]!;
+    if (i === 0) {
+      out = seg;
+      continue;
+    }
+    const joinWithDot = NUMERIC_SEGMENT.test(seg) && NUMERIC_SEGMENT.test(core[i - 1]!);
+    out += joinWithDot ? `.${seg}` : ` ${seg}`;
+  }
+  out = out.trim();
+  return isFree ? `${out} (Free)` : out;
+}
+
+function buildDescription(raw: { id: string; owned_by?: string }): string {
+  if (raw.id.endsWith("-free")) return "Free tier";
+  if (raw.owned_by && raw.owned_by !== "opencode") return `Provided by ${raw.owned_by}`;
+  return "";
+}
+
+function normalize(raw: ModelsApiResponse): Model[] {
+  if (!raw || !Array.isArray(raw.data)) return [];
+  const out: Model[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw.data) {
+    if (!entry || typeof entry.id !== "string" || entry.id.length === 0) continue;
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    const owned = typeof entry.owned_by === "string" ? entry.owned_by : undefined;
+    out.push({
+      id: entry.id,
+      name: humanizeModelId(entry.id),
+      description: buildDescription({ id: entry.id, owned_by: owned }),
+    });
+  }
+  return out;
+}
+
+function readCacheFile(): CacheFile | null {
+  try {
+    if (!existsSync(resolveCacheFile())) return null;
+    const raw = JSON.parse(readFileSync(resolveCacheFile(), "utf-8"));
+    if (!raw || raw.version !== 1 || typeof raw.fetchedAt !== "number") return null;
+    if (!Array.isArray(raw.models)) return null;
+    return raw as CacheFile;
+  } catch (err) {
+    log.debug(`Cache read failed: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+function writeCacheFile(models: Model[]): void {
+  try {
+    mkdirSync(dirname(resolveCacheFile()), { recursive: true });
+    const payload: CacheFile = { version: 1, fetchedAt: Date.now(), models };
+    writeFileSync(resolveCacheFile(), JSON.stringify(payload, null, 2));
+  } catch (err) {
+    log.debug(`Cache write failed: ${(err as Error).message}`);
+  }
+}
+
+async function fetchFromApi(): Promise<Model[] | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPENCODE_MODELS_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(OPENCODE_MODELS_ENDPOINT, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      log.debug(`Fetch returned HTTP ${res.status}`);
+      return null;
+    }
+    const json = (await res.json()) as ModelsApiResponse;
+    const models = normalize(json);
+    if (models.length === 0) {
+      log.debug("Fetch returned empty model list");
+      return null;
+    }
+    return models;
+  } catch (err) {
+    log.debug(`Fetch failed: ${(err as Error).message}`);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface GetModelsOptions {
+  /** Ignore any cached result and hit the network. */
+  refresh?: boolean;
+  /** Skip the network entirely — return cache-or-fallback only. */
+  offline?: boolean;
+}
+
+export interface ModelsResult {
+  models: Model[];
+  source: "network" | "cache" | "fallback";
+  fetchedAt?: number;
+}
+
+export async function getOpenCodeModels(
+  options: GetModelsOptions = {},
+): Promise<ModelsResult> {
+  const { refresh = false, offline = false } = options;
+  const now = Date.now();
+
+  if (!refresh && memoryCache && now - memoryCache.fetchedAt < OPENCODE_MODELS_CACHE_TTL_MS) {
+    return { models: memoryCache.models, source: "cache", fetchedAt: memoryCache.fetchedAt };
+  }
+
+  if (!refresh) {
+    const disk = readCacheFile();
+    if (disk && now - disk.fetchedAt < OPENCODE_MODELS_CACHE_TTL_MS) {
+      memoryCache = { fetchedAt: disk.fetchedAt, models: disk.models };
+      return { models: disk.models, source: "cache", fetchedAt: disk.fetchedAt };
+    }
+  }
+
+  if (offline) {
+    const disk = readCacheFile();
+    if (disk) {
+      memoryCache = { fetchedAt: disk.fetchedAt, models: disk.models };
+      return { models: disk.models, source: "cache", fetchedAt: disk.fetchedAt };
+    }
+    return { models: MODELS, source: "fallback" };
+  }
+
+  const fresh = await fetchFromApi();
+  if (fresh) {
+    memoryCache = { fetchedAt: Date.now(), models: fresh };
+    writeCacheFile(fresh);
+    return { models: fresh, source: "network", fetchedAt: memoryCache.fetchedAt };
+  }
+
+  const disk = readCacheFile();
+  if (disk) {
+    memoryCache = { fetchedAt: disk.fetchedAt, models: disk.models };
+    return { models: disk.models, source: "cache", fetchedAt: disk.fetchedAt };
+  }
+  return { models: MODELS, source: "fallback" };
+}
+
+export function clearOpenCodeModelsCache(): void {
+  memoryCache = null;
+  try {
+    if (existsSync(resolveCacheFile())) unlinkSync(resolveCacheFile());
+  } catch {}
+}
+
+// Test hook — reset in-memory cache without touching disk.
+export function __resetMemoryCacheForTests(): void {
+  memoryCache = null;
+}

--- a/tests/opencode-models.test.ts
+++ b/tests/opencode-models.test.ts
@@ -1,0 +1,229 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  __resetMemoryCacheForTests,
+  clearOpenCodeModelsCache,
+  getOpenCodeModels,
+  humanizeModelId,
+} from "../src/providers/opencode-models.js";
+import { MODELS } from "../src/constants.js";
+
+let tmpDir: string;
+let cacheFile: string;
+const originalFetch = globalThis.fetch;
+
+function installFetchMock(
+  impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): void {
+  globalThis.fetch = impl as typeof fetch;
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = originalFetch;
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "opencode-models-test-"));
+  cacheFile = join(tmpDir, "cache.json");
+  process.env["OPENCODE_MODELS_CACHE_FILE_OVERRIDE"] = cacheFile;
+  __resetMemoryCacheForTests();
+});
+
+afterEach(() => {
+  delete process.env["OPENCODE_MODELS_CACHE_FILE_OVERRIDE"];
+  restoreFetch();
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {}
+});
+
+describe("humanizeModelId", () => {
+  test("capitalizes known vendor segments", () => {
+    expect(humanizeModelId("minimax-m2.7")).toBe("MiniMax m2.7");
+    expect(humanizeModelId("kimi-k2.6")).toBe("Kimi k2.6");
+    expect(humanizeModelId("glm-5.1")).toBe("GLM 5.1");
+    expect(humanizeModelId("gpt-5.4-pro")).toBe("GPT 5.4 Pro");
+  });
+
+  test("joins consecutive numeric segments with dots", () => {
+    expect(humanizeModelId("claude-opus-4-7")).toBe("Claude Opus 4.7");
+    expect(humanizeModelId("claude-3-5-haiku")).toBe("Claude 3.5 Haiku");
+    expect(humanizeModelId("claude-haiku-4-5")).toBe("Claude Haiku 4.5");
+  });
+
+  test("strips -free suffix and appends (Free) tag", () => {
+    expect(humanizeModelId("minimax-m2.5-free")).toBe("MiniMax m2.5 (Free)");
+    expect(humanizeModelId("nemotron-3-super-free")).toBe("Nemotron 3 super (Free)");
+  });
+
+  test("preserves unknown segments untouched", () => {
+    expect(humanizeModelId("big-pickle")).toBe("big pickle");
+  });
+});
+
+describe("getOpenCodeModels", () => {
+  test("fetches from network when no cache", async () => {
+    installFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          object: "list",
+          data: [
+            { id: "minimax-m2.7", object: "model", owned_by: "opencode" },
+            { id: "kimi-k2.6", object: "model", owned_by: "opencode" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const result = await getOpenCodeModels();
+    expect(result.source).toBe("network");
+    expect(result.models.length).toBe(2);
+    expect(result.models[0]?.id).toBe("minimax-m2.7");
+    expect(result.models[0]?.name).toBe("MiniMax m2.7");
+    expect(existsSync(cacheFile)).toBe(true);
+  });
+
+  test("skips empty responses and falls back", async () => {
+    installFetchMock(async () =>
+      new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 }),
+    );
+    const result = await getOpenCodeModels();
+    expect(result.source).toBe("fallback");
+    expect(result.models).toBe(MODELS);
+  });
+
+  test("falls back to static MODELS when fetch fails with no cache", async () => {
+    installFetchMock(async () => {
+      throw new Error("network down");
+    });
+    const result = await getOpenCodeModels();
+    expect(result.source).toBe("fallback");
+    expect(result.models).toBe(MODELS);
+  });
+
+  test("uses disk cache on second call within TTL", async () => {
+    let calls = 0;
+    installFetchMock(async () => {
+      calls++;
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "glm-5", object: "model", owned_by: "opencode" }],
+        }),
+        { status: 200 },
+      );
+    });
+    await getOpenCodeModels();
+    __resetMemoryCacheForTests();
+    const second = await getOpenCodeModels();
+    expect(calls).toBe(1);
+    expect(second.source).toBe("cache");
+    expect(second.models[0]?.id).toBe("glm-5");
+  });
+
+  test("refresh=true bypasses cache", async () => {
+    writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        version: 1,
+        fetchedAt: Date.now(),
+        models: [{ id: "cached", name: "Cached", description: "" }],
+      }),
+    );
+    installFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "fresh", object: "model", owned_by: "opencode" }],
+        }),
+        { status: 200 },
+      ),
+    );
+    const result = await getOpenCodeModels({ refresh: true });
+    expect(result.source).toBe("network");
+    expect(result.models[0]?.id).toBe("fresh");
+  });
+
+  test("falls back to disk cache when fetch fails", async () => {
+    writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        version: 1,
+        fetchedAt: Date.now(),
+        models: [{ id: "cached-only", name: "Cached Only", description: "" }],
+      }),
+    );
+    // Cache is fresh → will be used before fetch. Expire it to force the
+    // fetch attempt:
+    const stale = {
+      version: 1,
+      fetchedAt: Date.now() - 2 * 60 * 60 * 1000, // 2h old
+      models: [{ id: "cached-only", name: "Cached Only", description: "" }],
+    };
+    writeFileSync(cacheFile, JSON.stringify(stale));
+    installFetchMock(async () => {
+      throw new Error("offline");
+    });
+    const result = await getOpenCodeModels();
+    expect(result.source).toBe("cache");
+    expect(result.models[0]?.id).toBe("cached-only");
+  });
+
+  test("non-200 response treated as failure", async () => {
+    installFetchMock(async () =>
+      new Response("server error", { status: 500 }),
+    );
+    const result = await getOpenCodeModels();
+    expect(result.source).toBe("fallback");
+  });
+
+  test("normalize deduplicates and drops invalid entries", async () => {
+    installFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          object: "list",
+          data: [
+            { id: "glm-5", owned_by: "opencode" },
+            { id: "glm-5", owned_by: "opencode" }, // duplicate
+            { id: "", owned_by: "opencode" }, // empty id
+            { object: "model" }, // missing id
+            { id: "kimi-k2.6", owned_by: "opencode" },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const result = await getOpenCodeModels();
+    expect(result.models.length).toBe(2);
+    expect(result.models.map((m) => m.id)).toEqual(["glm-5", "kimi-k2.6"]);
+  });
+
+  test("offline=true skips network and returns cache or fallback", async () => {
+    let fetchCalled = false;
+    installFetchMock(async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    });
+    const result = await getOpenCodeModels({ offline: true });
+    expect(fetchCalled).toBe(false);
+    expect(result.source).toBe("fallback");
+  });
+
+  test("clearOpenCodeModelsCache removes disk cache", async () => {
+    installFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "glm-5", owned_by: "opencode" }],
+        }),
+        { status: 200 },
+      ),
+    );
+    await getOpenCodeModels();
+    expect(existsSync(cacheFile)).toBe(true);
+    clearOpenCodeModelsCache();
+    expect(existsSync(cacheFile)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the OpenCode Go provider pull its model list live from
`https://opencode.ai/zen/v1/models` instead of relying on the hand-maintained
5-model array in `src/constants.ts`. The list had drifted: newer models
(`kimi-k2.6`, `qwen3.5-plus`, `qwen3.6-plus`, `big-pickle`, several free-tier
entries) were never selectable. After this change, `opencode-go --list` and
the interactive model picker show every model the Zen API reports (40 at the
time of writing).

Fetches are cached on disk at `~/.opencode-go-cli/opencode-models.json` with
a 1-hour TTL and fall back to an expanded built-in snapshot if the endpoint
is unreachable, so offline / degraded-network use still works.

## What changed

- **New:** `src/providers/opencode-models.ts` — `getOpenCodeModels()`,
  `humanizeModelId()`, memory + disk cache, 5s fetch timeout, graceful
  fallback.
- **`src/cli.ts`** — `selectModel`, `--list`, and `--model` validation go
  through a new async `resolveModelsForProvider()` with a short loading
  spinner. New `--refresh-models` flag (standalone or combined with
  `--list`) to force a cache bypass.
- **`src/constants.ts`** — expanded the fallback `MODELS` array from 5 to
  13 entries plus new endpoint / TTL / cache-path constants.
- **Tests:** `tests/opencode-models.test.ts` — 14 unit tests covering
  network, memory cache, disk cache, refresh, offline, fallback, non-200
  handling, dedup/invalid-entry filtering, and id-to-name humanization
  (including `-free` suffix and joining numeric version segments with
  dots).
- **Docs:** `README.md` and `CHANGELOG.md` updated.

Other providers (`openai`, `qwen`, `zai`) are untouched — each speaks a
different API and keeps its curated static list. The change is scoped to
`opencode`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — **93 pass** (was 79; 14 new), 0 fail
- [x] `bun run build` — clean (189.20 KB bundle)
- [x] `bun run src/index.ts --list` — 40 models rendered from the live API
- [x] `bun run src/index.ts --list --refresh-models` — forces refresh
- [x] `bun run src/index.ts --refresh-models` — standalone refresh command
- [x] Fetch failure / non-200 / offline paths covered by unit tests against
      a mocked `fetch`

## Notes

- Cache path is overrideable for tests via
  `OPENCODE_MODELS_CACHE_FILE_OVERRIDE` env var (used only by
  `tests/opencode-models.test.ts`).
- No new runtime dependencies — relies on the global `fetch` already in
  use elsewhere in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)