### PR TITLE
fix: raise Bun.serve idleTimeout so long upstream streams don't abort

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -106,6 +106,11 @@ export async function startProxy(port: number, provider: Provider, attempts = 1)
     try {
       server = Bun.serve({
         port: candidatePort,
+        // Upstream LLM streaming responses can idle well beyond Bun's
+        // 10s default while a remote provider is thinking. Raise the
+        // cap so long-running turns don't get cut off mid-stream with
+        // "[Bun.serve]: request timed out after 10 seconds".
+        idleTimeout: 255,
         async fetch(req) {
           const url = new URL(req.url);
           logger.debug(`${req.method} ${url.pathname}`);


### PR DESCRIPTION
## Summary

The local proxy is started with `Bun.serve({...})` without an explicit
`idleTimeout`. Bun's default is **10 seconds**, which cuts off any
request that idles longer than that — exactly what long upstream LLM
streams do while the provider thinks. Observed on multi-tool turns
with `kimi-k2.6` via OpenCode Zen:

```
[Bun.serve]: request timed out after 10 seconds. Pass \`idleTimeout\`
to configure.
```

The proxy's own debug logs showed the upstream happily emitting
`: OPENROUTER PROCESSING\n\n` keep-alives for 12+ seconds before the
first real chunk arrives — well past the 10s cap.

## Fix

Set `idleTimeout: 255` on the `Bun.serve()` call in
`src/proxy/server.ts`. 255s is Bun's maximum (the field is a single
byte) and is plenty for any realistic single-turn reasoning budget.

No behavior change for fast responses. Single-line change in a proxy
constructor — nothing else touched.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 101 pass, 0 fail
- [x] `bun run build` — clean
- [x] Repro: multi-minute turn against `kimi-k2.6` that previously
      aborted with the above timeout now streams through cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)