### PR TITLE
fix(windows): Claude Code fails to launch with ENOENT (uv_spawn)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -827,6 +827,9 @@ async function runClaudeCode(
     const child = spawn(claudePath, spawnArgs, {
       stdio: "inherit",
       env,
+      // On Windows the resolved launcher is a .cmd batch file; CreateProcess
+      // cannot run .cmd directly, it must go through cmd.exe (shell: true).
+      shell: process.platform === "win32",
     });
 
     child.on("error", (err) => {

--- a/src/path.ts
+++ b/src/path.ts
@@ -14,7 +14,18 @@ export function getInstallationPath(id: string = DEFAULT_INSTALLATION_ID): strin
 export function resolveClaudePath(): string {
   try {
     if (process.platform === "win32") {
-      return execSync("where claude", { encoding: "utf-8" }).trim().split(/\r?\n/)[0] ?? "claude";
+      const candidates = execSync("where claude", { encoding: "utf-8" })
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean);
+      // `where` lists the extension-less sh shim first. CreateProcess (used by
+      // child_process.spawn without a shell) cannot execute it, so pick the
+      // .cmd/.exe/.bat launcher that Windows actually runs.
+      return (
+        candidates.find((p) => /\.(cmd|exe|bat)$/i.test(p)) ??
+        candidates[0] ??
+        "claude"
+      );
     }
     return execSync("which claude", { encoding: "utf-8" }).trim();
   } catch {


### PR DESCRIPTION
## Problem

On Windows, `opencode-go` fails to launch Claude Code:

■  Failed to start Claude Code: ENOENT: no such file or directory, uv_spawn 'C:\Users...\AppData\Roaming\npm\claude'

Even though `claude` is installed and on PATH.

## Root cause

`resolveClaudePath()` runs `where claude` and takes the **first** line. On Windows, npm installs three shims side by side:

C:...\npm\claude        ← extension-less sh shim (listed FIRST)
C:...\npm\claude.cmd    ← Windows batch launcher
C:...\npm\claude.ps1

`child_process.spawn` without `shell: true` uses `CreateProcess`, which **cannot execute** the extension-less sh shim. So spawn fails with `ENOENT` — not "file not found", but "no way to execute it".

## Fix

1. **`src/path.ts`** — `resolveClaudePath()` now prefers the `.cmd` / `.exe` / `.bat` candidate from `where` instead of blindly taking line 0.
2. **`src/cli.ts`** — `runClaudeCode()` spawns with `shell: true` on win32, since `.cmd` batch files must run through `cmd.exe`.

Both changes are scoped to `process.platform === "win32"`; macOS/Linux behavior is untouched.

## Verification

- `tsc --noEmit` passes
- `where claude` now resolves to `...\claude.cmd`
- `claude.cmd --version` → `2.1.191 (Claude Code)` ✅
- Launch flow that previously ENOENT'd now starts Claude Code correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows launching so the app can start the Claude Code launcher reliably when it’s provided as a batch-style executable.
  * Enhanced launcher detection on Windows to better handle multiple installed paths and prefer a valid executable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->